### PR TITLE
FIX: Trigger tests/linting only on `master` pushes

### DIFF
--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -1,6 +1,10 @@
 name: Linting
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:

--- a/workflow-templates/plugin-tests.yml
+++ b/workflow-templates/plugin-tests.yml
@@ -1,6 +1,10 @@
 name: Plugin Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Triggering builds on push to any branch meant that everything was run twice on new PRs. For example see: https://github.com/discourse/discourse-voting/pull/61/checks (10 checks instead of 5)

(future TODO: change it to `main` when the times comes 😃)