### PR TITLE
FEATURE: Automatically update CI on official plugins

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -1,6 +1,6 @@
 name: Update CI
 
-on: 
+on:
   push:
     branches:
       - master
@@ -21,8 +21,8 @@ jobs:
           - "discourse-bbcode"
           - "discourse-bbcode-color"
           - "discourse-cakeday"
-          - "discourse-canned-replies"
           - "discourse-calendar"
+          - "discourse-canned-replies"
           - "discourse-categories-suppressed"
           - "discourse-characters-required"
           - "discourse-chat-integration"
@@ -31,46 +31,47 @@ jobs:
           - "discourse-crowd"
           - "discourse-data-explorer"
           - "discourse-encrypt"
+          - "discourse-fontawesome-pro"
           - "discourse-footnote"
           - "discourse-github"
           - "discourse-gradle-issue"
           - "discourse-graphviz"
           - "discourse-invite-tokens"
           - "discourse-knowledge-explorer"
+          - "discourse-login-with-amazon"
           - "discourse-logster-rate-limit-checker"
           - "discourse-logster-transporter"
           - "discourse-math"
           - "discourse-moderator-attention"
           - "discourse-no-bump"
           - "discourse-oauth2-basic"
+          - "discourse-openid-connect"
           - "discourse-patreon"
           - "discourse-perspective"
           - "discourse-plugin-discord-auth"
           - "discourse-plugin-linkedin-auth"
           - "discourse-plugin-office365-auth"
-          - "discourse-steam-login"
-          - "discourse-login-with-amazon"
           - "discourse-policy"
           - "discourse-prometheus"
           - "discourse-prometheus-alert-receiver"
           - "discourse-push-notifications"
+          - "discourse-restricted-replies"
+          - "discourse-rss-polling"
           - "discourse-saved-searches"
           - "discourse-signatures"
           - "discourse-sitemap"
           - "discourse-solved"
           - "discourse-spoiler-alert"
-          - "discourse-user-notes"
+          - "discourse-staff-alias"
+          - "discourse-steam-login"
+          - "discourse-teambuild"
           - "discourse-tooltips"
           - "discourse-translator"
           - "discourse-user-card-badges"
+          - "discourse-user-notes"
           - "discourse-voting"
           - "discourse-yearly-review"
-          - "discourse-openid-connect"
-          - "discourse-restricted-replies"
-          - "discourse-rss-polling"
           - "discourse-zendesk-plugin"
-          - "discourse-fontawesome-pro"
-          - "discourse-staff-alias"
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
@@ -90,10 +91,9 @@ jobs:
           cp ci/workflow-templates/*.yml plugin/.github/workflows
       - name: commit changes
         run: |
-          pwd
           cd plugin
           git config user.email "ci@discourse"
           git config user.name "Discourse CI"
           git add -A
-          git commit -m "Updates to CI workflows"
-          git push 
+          git commit -m "DEV: Updates to CI workflows"
+          git push

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -95,5 +95,5 @@ jobs:
           git config user.email "ci@discourse"
           git config user.name "Discourse CI"
           git add -A
-          git commit -m "DEV: Updates to CI workflows"
+          git commit -m "DEV: Update CI workflows"
           git push

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.CI_TOKEN }}
-          repository: justindirose/${{ matrix.repositories }}
+          repository: discourse/${{ matrix.repositories }}
           path: plugin
       - name: copy files
         run: |

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -1,0 +1,99 @@
+name: Update CI
+
+on: 
+  push:
+    branches:
+      - master
+    paths:
+      - 'workflow-templates/*.yml'
+
+jobs:
+  update-ci:
+    strategy:
+      matrix:
+        repositories:
+          - "discourse-adplugin"
+          - "discourse-affiliate"
+          - "discourse-akismet"
+          - "discourse-algolia"
+          - "discourse-assign"
+          - "discourse-auto-deactivate"
+          - "discourse-bbcode"
+          - "discourse-bbcode-color"
+          - "discourse-cakeday"
+          - "discourse-canned-replies"
+          - "discourse-calendar"
+          - "discourse-categories-suppressed"
+          - "discourse-characters-required"
+          - "discourse-chat-integration"
+          - "discourse-checklist"
+          - "discourse-code-review"
+          - "discourse-crowd"
+          - "discourse-data-explorer"
+          - "discourse-encrypt"
+          - "discourse-footnote"
+          - "discourse-github"
+          - "discourse-gradle-issue"
+          - "discourse-graphviz"
+          - "discourse-invite-tokens"
+          - "discourse-knowledge-explorer"
+          - "discourse-logster-rate-limit-checker"
+          - "discourse-logster-transporter"
+          - "discourse-math"
+          - "discourse-moderator-attention"
+          - "discourse-no-bump"
+          - "discourse-oauth2-basic"
+          - "discourse-patreon"
+          - "discourse-perspective"
+          - "discourse-plugin-discord-auth"
+          - "discourse-plugin-linkedin-auth"
+          - "discourse-plugin-office365-auth"
+          - "discourse-steam-login"
+          - "discourse-login-with-amazon"
+          - "discourse-policy"
+          - "discourse-prometheus"
+          - "discourse-prometheus-alert-receiver"
+          - "discourse-push-notifications"
+          - "discourse-saved-searches"
+          - "discourse-signatures"
+          - "discourse-sitemap"
+          - "discourse-solved"
+          - "discourse-spoiler-alert"
+          - "discourse-user-notes"
+          - "discourse-tooltips"
+          - "discourse-translator"
+          - "discourse-user-card-badges"
+          - "discourse-voting"
+          - "discourse-yearly-review"
+          - "discourse-openid-connect"
+          - "discourse-restricted-replies"
+          - "discourse-rss-polling"
+          - "discourse-zendesk-plugin"
+          - "discourse-fontawesome-pro"
+          - "discourse-staff-alias"
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: checkout workflows
+        uses: actions/checkout@v2
+        with:
+          path: ci
+      - name: checkout plugin
+        uses: actions/checkout@v2
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          repository: justindirose/${{ matrix.repositories }}
+          path: plugin
+      - name: copy files
+        run: |
+          [ ! -d "plugin/.github/workflows" ] && mkdir -p plugin/.github/workflows
+          cp ci/workflow-templates/*.yml plugin/.github/workflows
+      - name: commit changes
+        run: |
+          pwd
+          cd plugin
+          git config user.email "ci@discourse"
+          git config user.name "Discourse CI"
+          git add -A
+          git commit -m "Updates to CI workflows"
+          git push 


### PR DESCRIPTION
With the lack of a GitHub-official way to update repositories with template changes in the `.github` repository yet (and it looks like GitHub intends that feature to be Enterprise-only when they do roll it out), here's a PR rolling our own method. The main advantage here is we:

1. have a guard against incorrectly formatted PRs on official plugins, which, if merged, break core builds, and
2. have a single source of truth for our official plugin CI that's fully automated.

When these changes are merged to `master`, any changes to a `.yml` file in the `workflow-templates` directory will be copied to each official plugin listed under `matrix.repositories`. The nice thing about using the matrix approach is pushing these changes out happens in parallel.

As a v1, this assumes the proper linting packages already exist in the destination repositories. If they do not, CI will fail.

Additionally, when we add new official plugins, we'll need to:
1. Properly tag them as official as per normal means,
2. Ensure the proper linting packages are added manually,
3. (Optional) Copy the workflows from this repository using GitHub Actions templates so we don't have to make unnecessary changes to push CI out automatically, and
4. Add them to the `matrix.repositories` list in the `update_ci` workflow.

I believe I removed all core plugins and other outliers from the list below, but it would be worth having a second set of eyes review.