### PR TITLE
DEV: Add main to workflow branches

### DIFF
--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
 jobs:

--- a/workflow-templates/plugin-tests.yml
+++ b/workflow-templates/plugin-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Simple change to the CI workflows -- add main as an approved branch to run workflows on. This is a forward-looking commit with new repositories having `main` vs `master` as of October 1st.