### PR TITLE
FIX: Wrong plugin repo name

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -47,7 +47,7 @@ jobs:
           - "discourse-oauth2-basic"
           - "discourse-openid-connect"
           - "discourse-patreon"
-          - "discourse-perspective"
+          - "discourse-perspective-api"
           - "discourse-plugin-discord-auth"
           - "discourse-plugin-linkedin-auth"
           - "discourse-plugin-office365-auth"


### PR DESCRIPTION
Got the wrong repository name - this might need to be fixed in core too.