### PR TITLE
FIX: Skip prettier when no assets

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -72,7 +72,7 @@ jobs:
           - "discourse-voting"
           - "discourse-yearly-review"
           - "discourse-zendesk-plugin"
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: checkout workflows

--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Prettier
         run: |
           yarn prettier -v
+          [ -d "assets" ] && \
           yarn prettier --list-different \
             "assets/**/*.{scss,js,es6}"
 


### PR DESCRIPTION
Prettier does not currently have a method to skip running if no matches found. Some official plugins do not have an `assets` folder, so prettier will currently fail. This commit adds a directory check prior to running the prettier command, which should skip prettier if the assets directory does not exist.