### PR TITLE
FIX: Return exit 0 when assets not found

### DIFF
--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -39,9 +39,12 @@ jobs:
       - name: Prettier
         run: |
           yarn prettier -v
-          [ -d "assets" ] && \
-          yarn prettier --list-different \
-            "assets/**/*.{scss,js,es6}"
+          if [ -d "assets" ]; then \
+            yarn prettier --list-different \
+              "assets/**/*.{scss,js,es6}" \
+          else \
+            exit 0 \
+          fi
 
       - name: Rubocop
         run: bundle exec rubocop .


### PR DESCRIPTION
Using `[ -d "assets"] && yarn prettier ...` still returned `exit 1` if the directory was not found. This commit introduces logic to cleanly exit if `assets/` does not exist.