### PR TITLE
FIX: End if-then block and simplify code

### DIFF
--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -40,10 +40,7 @@ jobs:
         run: |
           yarn prettier -v
           if [ -d "assets" ]; then \
-            yarn prettier --list-different \
-              "assets/**/*.{scss,js,es6}" \
-          else \
-            exit 0 \
+            yarn prettier --list-different "assets/**/*.{scss,js,es6}" ; \
           fi
 
       - name: Rubocop


### PR DESCRIPTION
This was a problem because the if-then block did not have a proper end.

This commit also simplifies the code a bit because `exit 0` did not do
anything.

```
yarn run v1.22.5
$ /home/runner/work/discourse-encrypt/discourse-encrypt/node_modules/.bin/prettier -v
2.1.2
Done in 0.24s.
/home/runner/work/_temp/7c858813-e0e9-45b7-9b7f-3e87943c87e4.sh: line 8: syntax error: unexpected end of file
Error: Process completed with exit code 2.
```
