### PR TITLE
DEV: Upgrade to actions/cache@v2

### DIFF
--- a/workflow-templates/plugin-tests.yml
+++ b/workflow-templates/plugin-tests.yml
@@ -108,7 +108,7 @@ jobs:
           bundle config without 'development'
 
       - name: Bundler cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: bundler-cache
         with:
           path: vendor/bundle
@@ -124,7 +124,7 @@ jobs:
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
       - name: Yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir.outputs.dir }}


### PR DESCRIPTION
https://github.com/actions/cache/issues/381#issuecomment-662597653

v1 has issues with slow cache restoration. Tested with v2 in a branch on `knowledge-explorer` and it seemed to fire up quite a bit faster.