### PR TITLE
DEV: Remove dead code from plugin-tests.yml

### DIFF
--- a/workflow-templates/plugin-tests.yml
+++ b/workflow-templates/plugin-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: "${{ matrix.target }}-${{ matrix.build_types }}"
+    name: ${{ matrix.build_types }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
 
@@ -17,7 +17,6 @@ jobs:
       DISCOURSE_HOSTNAME: www.example.com
       RUBY_GLOBAL_METHOD_CACHE_SIZE: 131072
       BUILD_TYPE: ${{ matrix.build_types }}
-      TARGET: ${{ matrix.target }}
       RAILS_ENV: test
       PGHOST: localhost
       PGUSER: discourse
@@ -28,7 +27,6 @@ jobs:
 
       matrix:
         build_types: ["BACKEND", "FRONTEND"]
-        target: ["PLUGINS"]
         os: [ubuntu-latest]
         ruby: ["2.6"]
         postgres: ["12"]
@@ -140,28 +138,11 @@ jobs:
           bin/rake db:create
           bin/rake db:migrate
 
-      - name: Create parallel databases
-        if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'CORE'
-        run: |
-          bin/rake parallel:create
-          bin/rake parallel:migrate
-
-      - name: Core RSpec
-        if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'CORE'
-        run: |
-          bin/turbo_rspec
-          bin/rake plugin:spec
-
       - name: Plugin RSpec
-        if: env.BUILD_TYPE == 'BACKEND' && env.TARGET == 'PLUGINS' && steps.check_spec.outputs.files_exists == 'true'
+        if: env.BUILD_TYPE == 'BACKEND' && steps.check_spec.outputs.files_exists == 'true'
         run: bin/rake plugin:spec[${{ github.event.repository.name }}]
 
-      - name: Core QUnit
-        if: env.BUILD_TYPE == 'FRONTEND' && env.TARGET == 'CORE'
-        run: bundle exec rake qunit:test['1200000']
-        timeout-minutes: 30
-
       - name: Plugin QUnit
-        if: env.BUILD_TYPE == 'FRONTEND' && env.TARGET == 'PLUGINS' && steps.check_qunit.outputs.files_exists == 'true'
+        if: env.BUILD_TYPE == 'FRONTEND' && steps.check_qunit.outputs.files_exists == 'true'
         run: bundle exec rake plugin:qunit['${{ github.event.repository.name }}','1200000']
         timeout-minutes: 30


### PR DESCRIPTION
There's just one target. This removes code related to the deleted "core" target and all "target" parameterization.