### PR TITLE
DEV: Add discourse-subscriptions as official

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -64,6 +64,7 @@ jobs:
           - "discourse-spoiler-alert"
           - "discourse-staff-alias"
           - "discourse-steam-login"
+          - "discourse-subscriptions"
           - "discourse-teambuild"
           - "discourse-tooltips"
           - "discourse-translator"


### PR DESCRIPTION
Adds "discourse-subscriptions" to our CI workflows since it is becoming official.