### PR TITLE
FEATURE: Migrate to PRs for CI Updates

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -90,26 +90,12 @@ jobs:
         run: |
           [ ! -d "plugin/.github/workflows" ] && mkdir -p plugin/.github/workflows
           cp ci/workflow-templates/*.yml plugin/.github/workflows
-      - name: commit changes
-        run: |
-          cd plugin
-          git config user.email "ci@discourse"
-          git config user.name "Discourse CI"
-          git checkout update-ci 2>/dev/null || git checkout -b update-ci
-          git add -A
-          git commit -m "DEV: Update CI workflows"
-          git push --set-upstream origin update-ci
-      - name: create pull request
-        run: |
-          main_status=$(curl -s -o /dev/null -w "%{http_code}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/discourse/${{ matrix.repositories }}/branches/main)
-          if [[ $main_status == 200 ]]; then
-            export BRANCH="main"
-          else
-            export BRANCH="master"
-          fi
-          curl \
-            -u discoursebot:${{ secrets.CI_TOKEN }}
-            -X POST \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/discourse/${{ matrix.repositories }}/pulls \
-            -d '{"head":"update-ci","base":"'"$BRANCH"'","title":"DEV: Update CI","body":"Automatic CI update PR"}'
+      - name: create PR
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+          path: plugin
+          branch: update-ci
+          title: 'DEV: Update CI workflows'
+          body: |
+            Updates CI from discourse/.github

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -95,9 +95,10 @@ jobs:
           cd plugin
           git config user.email "ci@discourse"
           git config user.name "Discourse CI"
-          git checkout -b update-ci
+          git checkout update-ci 2>/dev/null || git checkout -b update-ci
           git add -A
           git commit -m "DEV: Update CI workflows"
+          git push --set-upstream origin update-ci
       - name: create pull request
         run: |
           curl \

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -95,6 +95,14 @@ jobs:
           cd plugin
           git config user.email "ci@discourse"
           git config user.name "Discourse CI"
+          git checkout -b update-ci
           git add -A
           git commit -m "DEV: Update CI workflows"
-          git push
+      - name: create pull request
+        run: |
+          curl \
+            -u discoursebot:${{ secrets.CI_TOKEN }}
+            -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/discourse/${{ matrix.repositories }}/pulls \
+            -d '{"head":"update-ci","base":"master","title":"DEV: Update CI","body":"Automatic CI update PR"}'

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -96,6 +96,7 @@ jobs:
           token: ${{ secrets.CI_TOKEN }}
           path: plugin
           branch: update-ci
+          commit-message: "DEV: Update CI workflows"
           title: 'DEV: Update CI workflows'
           body: |
             Updates CI from discourse/.github

--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -101,9 +101,15 @@ jobs:
           git push --set-upstream origin update-ci
       - name: create pull request
         run: |
+          main_status=$(curl -s -o /dev/null -w "%{http_code}" -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/discourse/${{ matrix.repositories }}/branches/main)
+          if [[ $main_status == 200 ]]; then
+            export BRANCH="main"
+          else
+            export BRANCH="master"
+          fi
           curl \
             -u discoursebot:${{ secrets.CI_TOKEN }}
             -X POST \
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/discourse/${{ matrix.repositories }}/pulls \
-            -d '{"head":"update-ci","base":"master","title":"DEV: Update CI","body":"Automatic CI update PR"}'
+            -d '{"head":"update-ci","base":"'"$BRANCH"'","title":"DEV: Update CI","body":"Automatic CI update PR"}'


### PR DESCRIPTION
@CvX I fixed up the permissions issue -- was a missing permission on the token we use.

That being said, we have PR requirements for a handful of official plugins and it sounds like we're going to move that way for all plugins soon. I whipped up this PR to move from committing to master to creating a PR from a branch. I wasn't able to test this on my personal account as the APIs are different (in fact I couldn't even locate the proper one). Mind having a look?