### PR TITLE
FIX: Ensure linting runs on test directory

### DIFF
--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -34,7 +34,7 @@ jobs:
         run: yarn install --dev
 
       - name: ESLint
-        run: yarn eslint --ext .js,.js.es6 --no-error-on-unmatched-pattern assets/javascripts
+        run: yarn eslint --ext .js,.js.es6 --no-error-on-unmatched-pattern {test,assets}/javascripts
 
       - name: Prettier
         run: |

--- a/workflow-templates/plugin-linting.yml
+++ b/workflow-templates/plugin-linting.yml
@@ -42,6 +42,9 @@ jobs:
           if [ -d "assets" ]; then \
             yarn prettier --list-different "assets/**/*.{scss,js,es6}" ; \
           fi
+          if [ -d "test" ]; then \
+            yarn prettier --list-different "test/**/*.{js,es6}" ; \
+          fi
 
       - name: Rubocop
         run: bundle exec rubocop .


### PR DESCRIPTION
Prettier and ESLint were not running on the `test` directory, which could cause broken core builds.