### PR TITLE
FIX: Reduce concurrency to avoid rate limits

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   update-ci:
     strategy:
+      max-parallel: 2
       matrix:
         repositories:
           - "discourse-adplugin"


### PR DESCRIPTION
PR reduces the number of concurrent requests made to update our CI to avoid hitting any GitHub rate limits. Will start at 2 for testing and could bump to probably 10 once this is confirmed to work.