### PR TITLE
FIX: Slow down rate even further

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   update-ci:
     strategy:
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         repositories:
           - "discourse-adplugin"
@@ -96,6 +96,7 @@ jobs:
         run: |
           [ ! -d "plugin/.github/workflows" ] && mkdir -p plugin/.github/workflows
           cp ci/workflow-templates/*.yml plugin/.github/workflows
+          sleep 1
       - name: create PR
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
Follow-up to #16 -- even two parallel jobs was too much. Reducing to 1 concurrent job and adding a 1 second sleep prior to making the call to create a PR.