### PR TITLE
FIX: Make deploy workflow really lazy

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           [ ! -d "plugin/.github/workflows" ] && mkdir -p plugin/.github/workflows
           cp ci/workflow-templates/*.yml plugin/.github/workflows
-          sleep 1
+          sleep 10
       - name: create PR
         uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
Following up #17, the deploy rate is still too fast due to this being a content creation event (can generate notifications and be clamped down much faster). Going to make the job really really lazy (by computer standards anyway) and put a 10 second gap in between.