### PR TITLE
DEV: Rename Knowledge Explorer to Docs

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -41,7 +41,7 @@ jobs:
           - "discourse-gradle-issue"
           - "discourse-graphviz"
           - "discourse-invite-tokens"
-          - "discourse-knowledge-explorer"
+          - "discourse-docs"
           - "discourse-login-with-amazon"
           - "discourse-logster-rate-limit-checker"
           - "discourse-logster-transporter"


### PR DESCRIPTION
Renames the repository for Knowledge Explorer to `discourse-docs`