### PR TITLE
DEV: Move to a manual workflow trigger

### DIFF
--- a/.github/workflows/update_ci.yml
+++ b/.github/workflows/update_ci.yml
@@ -1,11 +1,7 @@
 name: Update CI
 
 on:
-  push:
-    branches:
-      - master
-    paths:
-      - "workflow-templates/*.yml"
+  workflow_dispatch:
 
 jobs:
   update-ci:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Discourse Plugin CI Workflows
+
+This repository is responsible for distributing plugin CI workflows to [all official plugins](https://github.com/discourse/.github/blob/main/.github/workflows/update_ci.yml).
+
+## Deployment
+
+To trigger a deployment, visit the [Update CI](https://github.com/discourse/.github/actions/workflows/update_ci.yml) action page and click "Run workflow".


### PR DESCRIPTION
Triggering deploys manually isn't a big hassle, but allows us to commit/merge multiple things without automatically flooding all the repos. (and hitting API request limits 😉) 

The README assumes `main` branch so we need to rename after merging.