### PR TITLE
DEV: Update GitHub actions set-output uses

### DIFF
--- a/theme-workflow-templates/component-tests.yml
+++ b/theme-workflow-templates/component-tests.yml
@@ -28,7 +28,7 @@ jobs:
         shell: bash
         run: |
           if [ 0 -lt $(find tmp/component/test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
-            echo "::set-output name=tests_exist::true"
+            echo "tests_exist=true" >> $GITHUB_OUTPUT
           fi
 
   test:
@@ -94,7 +94,7 @@ jobs:
 
       - name: Get yarn cache directory
         id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Yarn cache
         uses: actions/cache@v3

--- a/workflow-templates/plugin-tests.yml
+++ b/workflow-templates/plugin-tests.yml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Get yarn cache directory
         id: yarn-cache-dir
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Yarn cache
         uses: actions/cache@v3
@@ -130,7 +130,7 @@ jobs:
         shell: bash
         run: |
           if [ 0 -lt $(find plugins/${{ github.event.repository.name }}/spec -type f -name "*.rb" 2> /dev/null | wc -l) ]; then
-            echo "::set-output name=files_exist::true"
+            echo "files_exist=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Plugin RSpec
@@ -142,7 +142,7 @@ jobs:
         shell: bash
         run: |
           if [ 0 -lt $(find plugins/${{ github.event.repository.name }}/test/javascripts -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
-            echo "::set-output name=files_exist::true"
+            echo "files_exist=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Plugin QUnit


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/