### PR TITLE
Add discourse-newsletter-integration plugin

### DIFF
--- a/plugins.yml
+++ b/plugins.yml
@@ -48,6 +48,7 @@ repositories:
   - "discourse-math"
   - "discourse-microsoft-auth"
   - "discourse-moderator-attention"
+  - "discourse-newsletter-integration"
   - "discourse-no-bump"
   - "discourse-oauth2-basic"
   - "discourse-openid-connect"


### PR DESCRIPTION
discourse-newsletter-integration is an official plugin: https://github.com/discourse/discourse-newsletter-integration.