### PR TITLE
DEV: Update system test screenshot path for test artifacts

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -298,4 +298,4 @@ jobs:
         if: matrix.build_type == 'system' && failure()
         with:
           name: failed-system-test-screenshots
-          path: tmp/screenshots/
+          path: tmp/capybara/*.png


### PR DESCRIPTION
The folder has moved as seen in https://github.com/discourse/discourse-post-voting/actions/runs/5953589402/job/16148190678?pr=159 and also in core https://github.com/discourse/discourse/blob/main/.github/workflows/tests.yml#L225-L227