### PR TITLE
DEV: Use correct folder when searching for assets to prettify

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -54,7 +54,7 @@ jobs:
         shell: bash
         run: |
           yarn prettier -v
-          if [ 0 -lt $(find assets admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2> /dev/null | wc -l) ]; then
+          if [ -n "$(find assets admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2>/dev/null)" ]; then
             yarn prettier --list-different "{.,admin}/assets/**/*.{scss,js,es6,hbs}"
           fi
           if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then

--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           yarn prettier -v
           if [ 0 -lt $(find assets admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2> /dev/null | wc -l) ]; then
-            yarn prettier --list-different "**/assets/**/*.{scss,js,es6,hbs}"
+            yarn prettier --list-different "{.,admin}/assets/**/*.{scss,js,es6,hbs}"
           fi
           if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
             yarn prettier --list-different "test/**/*.{js,es6}"

--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           yarn prettier -v
           if [ 0 -lt $(find assets admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2> /dev/null | wc -l) ]; then
-            yarn prettier --list-different "*/assets/**/*.{scss,js,es6,hbs}"
+            yarn prettier --list-different "**/assets/**/*.{scss,js,es6,hbs}"
           fi
           if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
             yarn prettier --list-different "test/**/*.{js,es6}"

--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -54,8 +54,11 @@ jobs:
         shell: bash
         run: |
           yarn prettier -v
-          if [ -n "$(find assets admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2>/dev/null)" ]; then
-            yarn prettier --list-different "{.,admin}/assets/**/*.{scss,js,es6,hbs}"
+          if [ -n "$(find assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2>/dev/null)" ]; then
+            yarn prettier --list-different "assets/**/*.{scss,js,es6,hbs}"
+          fi
+          if [ -n "$(find admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2>/dev/null)" ]; then
+            yarn prettier --list-different "admin/assets/**/*.{scss,js,es6,hbs}"
           fi
           if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
             yarn prettier --list-different "test/**/*.{js,es6}"

--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           yarn prettier -v
           if [ 0 -lt $(find assets admin/assets -type f \( -name "*.scss" -or -name "*.js" -or -name "*.es6" -or -name "*.hbs" \) 2> /dev/null | wc -l) ]; then
-            yarn prettier --list-different "assets/**/*.{scss,js,es6,hbs}"
+            yarn prettier --list-different "*/assets/**/*.{scss,js,es6,hbs}"
           fi
           if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
             yarn prettier --list-different "test/**/*.{js,es6}"


### PR DESCRIPTION
In plugins that have no `scss,js,es6,hbs` files in `assets` folders, but have them `admin/assets`, the if-statement will still be true and runs only for `assets` folders.

This update makes sure we run both `assets` and `admin/assets` folders (and prevents this command from failing if there is only assets in `admin` but not `assets`).