### PR TITLE
DEV: Support running system tests for themes

### DIFF
--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -54,10 +54,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: yarn ember-template-lint --no-error-on-unmatched-pattern javascripts
 
-  check:
+  check_for_tests:
     runs-on: ubuntu-latest
     outputs:
-      tests_exist: ${{ steps.check_tests.outputs.tests_exist }}
+      matrix: ${{ steps.check_tests.outputs.matrix }}
+      has_tests: ${{ steps.check_tests.outputs.has_tests }}
 
     steps:
       - name: Install component
@@ -67,25 +68,43 @@ jobs:
           path: tmp/component
           fetch-depth: 1
 
-      - name: Check QUnit existence
+      - name: Check For Test Types
         id: check_tests
-        shell: bash
+        shell: ruby {0}
+        working-directory: tmp/component
         run: |
-          if [ 0 -lt $(find tmp/component/test -type f \( -name "*.js" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
-            echo "tests_exist=true" >> $GITHUB_OUTPUT
-          fi
+          require 'json'
+
+          matrix = []
+
+          matrix << 'frontend' if Dir.glob("test/**/*.{js,es6}").any?
+          matrix << 'system' if Dir.glob("spec/system/**/*.rb").any?
+
+          puts "Detected test types: #{matrix.inspect}"
+
+          File.write(ENV["GITHUB_OUTPUT"], "matrix=#{matrix.to_json}\n", mode: 'a+')
+
+          if matrix.any?
+            File.write(ENV["GITHUB_OUTPUT"], "has_tests=true\n", mode: 'a+')
+          end
 
   test:
-    needs: check
-    if: ${{ needs.check.outputs.tests_exist }}
+    name: ${{ matrix.build_type || '' }}_tests
+    needs: check_for_tests
+    if: ${{ needs.check_for_tests.outputs.has_tests }}
     runs-on: ubuntu-latest
     container: discourse/discourse_test:slim-browsers
     timeout-minutes: 15
 
+    strategy:
+      fail-fast: false
+
+      matrix:
+        build_type: ${{ fromJSON(needs.check_for_tests.outputs.matrix) }}
+
     env:
       DISCOURSE_HOSTNAME: www.example.com
       RUBY_GLOBAL_METHOD_CACHE_SIZE: 131072
-      RAILS_ENV: development
       PGUSER: discourse
       PGPASSWORD: discourse
 
@@ -133,6 +152,16 @@ jobs:
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-gem-
+
+      - name: Sets test Rails ENV
+        if: matrix.build_type == 'system'
+        run: |
+          echo "RAILS_ENV=test" >> $GITHUB_ENV
+
+      - name: Sets development Rails ENV
+        if: matrix.build_type == 'frontend'
+        run: |
+          echo "RAILS_ENV=development" >> $GITHUB_ENV
 
       - name: Setup gems
         run: |
@@ -193,12 +222,30 @@ jobs:
         if: steps.app-cache.outputs.cache-hit != 'true'
         run: rm -rf tmp/app-cache/uploads && cp -r public/uploads tmp/app-cache/uploads
 
+      - name: Ember Build for System Tests
+        if: matrix.build_type == 'system'
+        run: bin/ember-cli --build
+
+      - name: Theme System Tests
+        if: matrix.build_type == 'system'
+        run: bin/rspec --format documentation tmp/component/spec/system
+        timeout-minutes: 10
+
+      - name: Upload failed system test screenshots
+        uses: actions/upload-artifact@v3
+        if: matrix.build_type == 'system' && failure()
+        with:
+          name: failed-system-test-screenshots
+          path: tmp/capybara/*.png
+
       - name: Create theme archive
+        if: matrix.build_type == 'frontend'
         run: |
           cd tmp/component
           git archive --format=tar.gz HEAD > ../../theme.tar.gz
 
       - name: Component QUnit
+        if: matrix.build_type == 'frontend'
         run: |
           THEME_NAME=$(ruby -e 'require "json"; puts JSON.parse(File.read("tmp/component/about.json"))["name"]')
           THEME_ARCHIVE=theme.tar.gz bundle exec rake themes:install:archive


### PR DESCRIPTION
Why this change?

Discourse core will soon support RSpec system tests for themes so we are
updating the workflow template here to support it as well.

### Reviewer notes

I tested the new workflow on an existing theme with system tests which can be found [here](https://github.com/discourse/discourse-minimal-category-boxes/pull/26).