### PR TITLE
FIX: Include `RAILS_ENV` in theme test job cache key

### DIFF
--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -8,7 +8,7 @@ on:
         required: false
     secrets:
       ssh_private_key:
-        description: 'Optional SSH private key to be used when cloning additional plugin repos'
+        description: "Optional SSH private key to be used when cloning additional plugin repos"
         required: false
 
 concurrency:
@@ -199,6 +199,7 @@ jobs:
           key: >-
             ${{ hashFiles('.github/workflows/tests.yml') }}-
             ${{ hashFiles('db/**/*', 'plugins/**/db/**/*') }}-
+            ${{ env.RAILS_ENV }}
 
       - name: Restore database from cache
         if: steps.app-cache.outputs.cache-hit == 'true'


### PR DESCRIPTION
Otherwise, we can end up restoring the development env database into the
test env database.