### PR TITLE
FIX: Downgrade to ruby 3.1

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.1"
           bundler-cache: true
 
       - name: ESLint


### PR DESCRIPTION
Older versions of rubocop don't play well with 3.2. Wait with the upgrade until we update linting in all the repos.