### PR TITLE
DEV: Update ruby to 3.2 again

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Set up ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
           bundler-cache: true
 
       - name: ESLint


### PR DESCRIPTION
Now that we updated rubocop in all plugin repos it should be good.