### PR TITLE
Add default stale-pr-close workflow

### DIFF
--- a/.github/workflows/stale-pr-closer.yml
+++ b/.github/workflows/stale-pr-closer.yml
@@ -1,0 +1,19 @@
+name: "Close stale PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 14
+          stale-pr-message: "This pull request has been automatically marked as stale because it has been open for 60 days with no activity. To keep it open, remove the stale tag, push code, or add a comment. Otherwise, it will be closed in 14 days."
+          exempt-pr-labels: dependencies


### PR DESCRIPTION
So that we don't keep PR forever.

By default, we'll warn after 60 days of inactivity and close it after another 14 days.