### PR TITLE
DEV: Remove Chrome before running tests

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -202,6 +202,12 @@ jobs:
           bundle install --jobs 4
           bundle clean
 
+      # We are in the midst of replacing Chrome for Chromium in our base image since it doesn't ship a binary for arm64 on
+      # linux. This can be removed in the future when the base image no longer installs Chrome.
+      - name: Remove Chrome
+        continue-on-error: true
+        run: apt remove -y google-chrome-stable
+
       - name: Lint English locale
         if: matrix.build_type == 'backend'
         run: bundle exec ruby script/i18n_lint.rb "plugins/${{ env.PLUGIN_NAME }}/locales/{client,server}.en.yml"

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -180,6 +180,12 @@ jobs:
           bundle install --jobs 4
           bundle clean
 
+      # We are in the midst of replacing Chrome for Chromium in our base image since it doesn't ship a binary for arm64 on
+      # linux. This can be removed in the future when the base image no longer installs Chrome.
+      - name: Remove Chrome
+        continue-on-error: true
+        run: apt remove -y google-chrome-stable
+
       - name: Lint English locale
         run: bundle exec ruby script/i18n_lint.rb "tmp/component/locales/en.yml"
 


### PR DESCRIPTION
Why this change?

This is a follow-up to https://github.com/discourse/discourse/commit/99921120a1fe2d59e70036c85486c81325f36715
where both Chrome and Chromium are now installed in the test image as we
transition to using Chromium only in our test base image since supports both x86
and arm64 with binaries whereas Chrome still does not ship a binary for `linux/arm64`.
