### PR TITLE
DEV: Update actions cache keys for bundler

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -185,13 +185,20 @@ jobs:
           sudo -E -u postgres script/start_test_db.rb
           sudo -u postgres psql -c "CREATE ROLE $PGUSER LOGIN SUPERUSER PASSWORD '$PGPASSWORD';"
 
+      - name: Container envs
+        id: container-envs
+        run: |
+          echo "ruby_version=$RUBY_VERSION" >> $GITHUB_OUTPUT
+          echo "debian_release=$DEBIAN_RELEASE" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Bundler cache
         uses: actions/cache@v3
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-
+            ${{ runner.os }}-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}-gem-
 
       - name: Setup gems
         run: |
@@ -202,11 +209,10 @@ jobs:
           bundle install --jobs 4
           bundle clean
 
-      # We are in the midst of replacing Chrome for Chromium in our base image since it doesn't ship a binary for arm64 on
-      # linux. This can be removed in the future when the base image no longer installs Chrome.
-      - name: Remove Chrome
+      - name: Remove Chromium
+        if: matrix.build_type == 'system'
         continue-on-error: true
-        run: apt remove -y google-chrome-stable
+        run: apt remove -y chromium chromium-driver
 
       - name: Lint English locale
         if: matrix.build_type == 'backend'

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -163,13 +163,20 @@ jobs:
           sudo -E -u postgres script/start_test_db.rb
           sudo -u postgres psql -c "CREATE ROLE $PGUSER LOGIN SUPERUSER PASSWORD '$PGPASSWORD';"
 
+      - name: Container envs
+        id: container-envs
+        run: |
+          echo "ruby_version=$RUBY_VERSION" >> $GITHUB_OUTPUT
+          echo "debian_release=$DEBIAN_RELEASE" >> $GITHUB_OUTPUT
+        shell: bash
+
       - name: Bundler cache
         uses: actions/cache@v3
         with:
           path: vendor/bundle
-          key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}-gem-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: |
-            ${{ runner.os }}-gem-
+            ${{ runner.os }}-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}-gem-
 
       - name: Setup gems
         run: |
@@ -180,11 +187,10 @@ jobs:
           bundle install --jobs 4
           bundle clean
 
-      # We are in the midst of replacing Chrome for Chromium in our base image since it doesn't ship a binary for arm64 on
-      # linux. This can be removed in the future when the base image no longer installs Chrome.
-      - name: Remove Chrome
+      - name: Remove Chromium
+        if: matrix.build_type == 'system'
         continue-on-error: true
-        run: apt remove -y google-chrome-stable
+        run: apt remove -y chromium chromium-driver
 
       - name: Lint English locale
         run: bundle exec ruby script/i18n_lint.rb "tmp/component/locales/en.yml"


### PR DESCRIPTION
Bundle cache should be keyed on ruby version as well as the debian release name. Changes to the debian release can affect the way gems are installed since gems may link to different versions of binaries.