### PR TITLE
Update discourse-theme.yml

### DIFF
--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -49,13 +49,13 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          yarn prettier -v
+          yarn prettier --version
           files=$(find javascripts desktop mobile common scss -type f \( -name "*.scss" -or -name "*.js" -or -name "*.gjs" -or -name "*.es6" \) 2> /dev/null) || true
           if [ -n "$files" ]; then
-            yarn prettier --list-different $files
+            yarn prettier --check $files
           fi
-          if [ 0 -lt $(find test -type f \( -name "*.js" -or -name "*.gjs" -or -name "*.es6" \) 2> /dev/null | wc -l) ]; then
-            yarn prettier --list-different "test/**/*.{js,gjs,es6}"
+          if [ 0 -lt "$(find test -type f \( -name '*.js' -or -name '*.gjs' -or -name '*.es6' \) 2> /dev/null | wc -l)" ]; then
+            yarn prettier --check "test/**/*.{js,gjs,es6}"
           fi
 
       - name: Ember template lint


### PR DESCRIPTION
* Use `--check` instead of `--list-different` to print a human-friendly summary message and paths to unformatted files.
* Quote this to prevent word splitting. See https://github.com/koalaman/shellcheck/wiki/SC2046
* Use `--version` instead of `-v` for verbosity`


#### Example outputs

```bash
yarn prettier --list-different $files

javascripts/discourse/connectors/below-footer/custom-footer.js
javascripts/discourse/components/custom-header.js
javascripts/discourse/initializers/init-header-links.js
common/common.scss
common/color_definitions.scss
error Command failed with exit code 1.
```

```bash
yarn prettier --check $files

Checking formatting...
[warn] javascripts/discourse/connectors/below-footer/custom-footer.js
[warn] javascripts/discourse/components/custom-header.js
[warn] javascripts/discourse/initializers/init-header-links.js
[warn] common/common.scss
[warn] common/color_definitions.scss
[warn] Code style issues found in 5 files. Forgot to run Prettier?
error Command failed with exit code 1.
```
