### PR TITLE
DEV: Update discourse-theme workflow to run all rspec tests

### DIFF
--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -69,6 +69,7 @@ jobs:
       has_tests: ${{ steps.check_tests.outputs.has_tests }}
       has_compatibility_file: ${{ steps.check_tests.outputs.has_compatibility_file }}
       has_specs: ${{ steps.check_tests.outputs.has_specs }}
+      has_system_specs: ${{ steps.check_tests.outputs.has_system_specs }}
 
     steps:
       - name: Install component
@@ -85,18 +86,20 @@ jobs:
         run: |
           require 'json'
 
-          has_specs = Dir.glob("spec/system/**/*.rb").any?
+          has_system_specs = Dir.glob("spec/system/**/*.rb").any?
+          has_specs = Dir.glob("spec/**/*.rb").any?
           has_compatibility_file = File.exist?(".discourse-compatibility")
 
           matrix = []
 
           matrix << 'frontend' if Dir.glob("test/**/*.{js,es6,gjs}").any?
-          matrix << 'system' if has_specs || has_compatibility_file
+          matrix << 'rspec' if has_specs || has_compatibility_file
 
           puts "Running jobs: #{matrix.inspect}"
 
           File.write(ENV["GITHUB_OUTPUT"], "matrix=#{matrix.to_json}\n", mode: 'a+')
           File.write(ENV["GITHUB_OUTPUT"], "has_specs=true\n", mode: 'a+') if has_specs
+          File.write(ENV["GITHUB_OUTPUT"], "has_system_specs=true\n", mode: 'a+') if has_specs
           File.write(ENV["GITHUB_OUTPUT"], "has_compatibility_file=true\n", mode: 'a+') if has_compatibility_file
 
           if matrix.any?
@@ -188,7 +191,7 @@ jobs:
           bundle clean
 
       - name: Remove Chromium
-        if: matrix.build_type == 'system'
+        if: matrix.build_type == 'rspec' && needs.check_for_tests.outputs.has_system_specs
         continue-on-error: true
         run: apt remove -y chromium chromium-driver
 
@@ -253,23 +256,23 @@ jobs:
         run: rm -rf tmp/app-cache/uploads && cp -r public/uploads tmp/app-cache/uploads
 
       - name: Validate discourse-compatibility
-        if: matrix.build_type == 'system' && needs.check_for_tests.outputs.has_compatibility_file && !inputs.core_ref
+        if: matrix.build_type == 'rspec' && needs.check_for_tests.outputs.has_compatibility_file && !inputs.core_ref
         run: bin/rake "compatibility:validate[tmp/component/.discourse-compatibility]"
 
       - name: Ember Build for System Tests
-        if: matrix.build_type == 'system' && needs.check_for_tests.outputs.has_specs
+        if: matrix.build_type == 'rspec' && needs.check_for_tests.outputs.has_system_specs
         run: bin/ember-cli --build
 
-      - name: Theme System Tests
-        if: matrix.build_type == 'system' && needs.check_for_tests.outputs.has_specs
+      - name: Theme RSpec Tests
+        if: matrix.build_type == 'rspec'
         env:
           CAPYBARA_DEFAULT_MAX_WAIT_TIME: 10
-        run: bin/rspec --format documentation tmp/component/spec/system
+        run: bin/rspec --format documentation tmp/component/spec
         timeout-minutes: 10
 
       - name: Upload failed system test screenshots
         uses: actions/upload-artifact@v3
-        if: matrix.build_type == 'system' && failure()
+        if: matrix.build_type == 'rspec' && needs.check_for_tests.outputs.has_system_specs && failure()
         with:
           name: failed-system-test-screenshots
           path: tmp/capybara/*.png


### PR DESCRIPTION
As part of https://github.com/discourse/discourse/pull/26845, we are now
allowing theme developers to write end-to-end theme settings migration
tests. This means that we need to run all RSpec tests instead of just
system tests.
