### PR TITLE
Enable cheap source maps for theme/plugin CI

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -140,6 +140,7 @@ jobs:
       PGUSER: discourse
       PGPASSWORD: discourse
       PLUGIN_NAME: ${{ inputs.name || github.event.repository.name }}
+      CHEAP_SOURCE_MAPS: "1"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -127,6 +127,7 @@ jobs:
       PGPASSWORD: discourse
       RAILS_ENV: test
       DISCOURSE_DEV_DB: discourse_test
+      CHEAP_SOURCE_MAPS: "1"
 
     steps:
       - name: Set working directory owner


### PR DESCRIPTION
In core's CI (which uses larger GitHub actions runners) this saved 7s. It should save even more time on theme/plugin CI, which tend to use the free runners with lower memory/cpu specs.