### PR TITLE
FIX: Add `core_ref` to the `group` key

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -18,7 +18,7 @@ on:
         required: false
 
 concurrency:
-  group: discourse-plugin-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  group: discourse-plugin-${{ format('{0}-{1}-{2}', github.head_ref || github.run_number, github.job, inputs.core_ref) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -15,7 +15,7 @@ on:
         required: false
 
 concurrency:
-  group: discourse-theme-${{ format('{0}-{1}', github.head_ref || github.run_number, github.job) }}
+  group: discourse-theme-${{ format('{0}-{1}-{2}', github.head_ref || github.run_number, github.job, inputs.core_ref) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Allows running jobs with different `core_ref`s simultaneously 