### PR TITLE
DEV: update plugin and theme workflows to support both yarn & pnpm

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -21,6 +21,9 @@ concurrency:
   group: discourse-plugin-${{ format('{0}-{1}-{2}', github.head_ref || github.run_number, github.job, inputs.core_ref) }}
   cancel-in-progress: true
 
+env:
+  JS_PKG_MANAGER_NULL_VALUE: "none"
+
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -36,21 +39,27 @@ jobs:
           if [ -f yarn.lock ]; then
             echo "Using Yarn"
             echo "manager=yarn" >> $GITHUB_OUTPUT
-          else
+          elif [ -f pnpm-lock.yaml ]; then
             echo "Using pnpm"
             echo "manager=pnpm" >> $GITHUB_OUTPUT
+          else
+            echo "No JS package manager detected"
+            echo "manager=${{ env.JS_PKG_MANAGER_NULL_VALUE }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Install package manager
+        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         run: npm install -g ${{ steps.js-pkg-manager.outputs.manager }}
 
       - name: Set up Node.js
+        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: ${{ steps.js-pkg-manager.outputs.manager }}
 
       - name: Install JS dependencies
+        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         run:  ${{ steps.js-pkg-manager.outputs.manager }} install --frozen-lockfile
 
       - name: Set up ruby
@@ -60,7 +69,7 @@ jobs:
           bundler-cache: true
 
       - name: ESLint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         run: |
           if test -f .prettierrc.cjs; then
             ${{ steps.js-pkg-manager.outputs.manager }} eslint --ext .js,.gjs,.js.es6 --no-error-on-unmatched-pattern {test,assets,admin/assets}/javascripts
@@ -69,7 +78,7 @@ jobs:
           fi
 
       - name: Prettier
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         shell: bash
         run: |
           ${{ steps.js-pkg-manager.outputs.manager }} prettier -v
@@ -84,12 +93,12 @@ jobs:
           fi
 
       - name: Ember template lint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         run: ${{ steps.js-pkg-manager.outputs.manager }} ember-template-lint --no-error-on-unmatched-pattern assets/javascripts
 
       # Separated due to https://github.com/ember-template-lint/ember-template-lint/issues/2758
       - name: Ember template lint (admin)
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         run: ${{ steps.js-pkg-manager.outputs.manager }} ember-template-lint --no-error-on-unmatched-pattern admin/assets/javascripts
 
       - name: Rubocop

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -18,6 +18,9 @@ concurrency:
   group: discourse-theme-${{ format('{0}-{1}-{2}', github.head_ref || github.run_number, github.job, inputs.core_ref) }}
   cancel-in-progress: true
 
+env:
+  JS_PKG_MANAGER_NULL_VALUE: "none"
+
 jobs:
   linting:
     runs-on: ubuntu-latest
@@ -33,25 +36,31 @@ jobs:
           if [ -f yarn.lock ]; then
             echo "Using Yarn"
             echo "manager=yarn" >> $GITHUB_OUTPUT
-          else
+          elif [ -f pnpm-lock.yaml ]; then
             echo "Using pnpm"
             echo "manager=pnpm" >> $GITHUB_OUTPUT
+          else
+            echo "No JS package manager detected"
+            echo "manager=${{ env.JS_PKG_MANAGER_NULL_VALUE }}" >> $GITHUB_OUTPUT
           fi
 
       - name: Install package manager
+        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         run: npm install -g ${{ steps.js-pkg-manager.outputs.manager }}
 
       - name: Set up Node.js
+        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: ${{ steps.js-pkg-manager.outputs.manager }}
 
       - name: Install dependencies
+        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         run:  ${{ steps.js-pkg-manager.outputs.manager }} install --frozen-lockfile
 
       - name: ESLint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         run: |
           if test -f .prettierrc.cjs; then
             ${{ steps.js-pkg-manager.outputs.manager }} eslint --ext .js,.gjs,.js.es6 --no-error-on-unmatched-pattern {test,javascripts}
@@ -60,7 +69,7 @@ jobs:
           fi
 
       - name: Prettier
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         shell: bash
         run: |
           ${{ steps.js-pkg-manager.outputs.manager }} prettier --version
@@ -73,7 +82,7 @@ jobs:
           fi
 
       - name: Ember template lint
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
         run: ${{ steps.js-pkg-manager.outputs.manager }} ember-template-lint --no-error-on-unmatched-pattern javascripts
 
   check_for_tests:


### PR DESCRIPTION
This is a non-breaking change to prepare for all officially supported plugins & themes to switch over to using `pnpm`.
Once all such plugins & themes are converted, we will remove references to yarn in these workflows and increment VERSION.

See https://meta.discourse.org/t/324521 for more detail on this change.

In the pnpm flow, we don't need to pull from github's cache for a restore of previous builds as it's overall slower than directly installing via pnpm.

#### Testing
For projects without JS lockfiles like discourse-tickets, we don't run the JS linting steps otherwise those will run into errors. See https://github.com/tyb-talks/discourse-tickets/actions for test runs.
