### PR TITLE
DEV: Add MinIO step for system specs

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -165,6 +165,8 @@ jobs:
       PGPASSWORD: discourse
       PLUGIN_NAME: ${{ inputs.name || github.event.repository.name }}
       CHEAP_SOURCE_MAPS: "1"
+      MINIO_RUNNER_LOG_LEVEL: DEBUG
+      MINIO_RUNNER_INSTALL_DIR: /home/discourse/.minio_runner
 
     strategy:
       fail-fast: false
@@ -361,6 +363,23 @@ jobs:
             exit 1
           fi
         timeout-minutes: 5
+
+      - name: Add hosts to /etc/hosts, otherwise Chrome cannot reach minio
+        if: matrix.build_type == 'system'
+        run: |
+          echo "127.0.0.1 minio.local" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 discoursetest.minio.local" | sudo tee -a /etc/hosts
+
+      - name: Minio cache
+        if: matrix.build_type == 'system'
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.MINIO_RUNNER_INSTALL_DIR }}
+          key: ${{ runner.os }}-${{ steps.container-envs.outputs.ruby_version }}-${{ steps.container-envs.outputs.debian_release }}
+
+      - name: Ensure latest minio binary installed for Core System Tests
+        if: matrix.build_type == 'system'
+        run: bundle exec ruby script/install_minio_binaries.rb
 
       - name: Plugin System Tests
         if: matrix.build_type == 'system'


### PR DESCRIPTION
System specs that depend on S3 uploads are currently not supported on CI for plugins because MinIO, which is required for S3 system specs, isn't installed in the plugin tests workflow. This PR adds steps to install MinIO to support S3 system specs. See https://github.com/discourse-org/discourse-new-features-feeds/pull/47 for an example.