### PR TITLE
Temporarily allow failure on i18n lint

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -248,6 +248,7 @@ jobs:
       - name: Lint English locale
         if: matrix.build_type == 'backend'
         run: bundle exec ruby script/i18n_lint.rb "plugins/${{ env.PLUGIN_NAME }}/config/locales/{client,server}.en.yml"
+        continue-on-error: true
 
       - name: Get yarn cache directory
         id: yarn-cache-dir


### PR DESCRIPTION
After fixing this earlier today, we've been alerted to failures across many repositories. Disabling this for now while we improve guidance on how to resolve issues.