### PR TITLE
Use discourse self hosted runners for test-template workflow

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -16,6 +16,9 @@ on:
         type: string
         required: false
         default: "ubuntu-latest"
+      container:
+        type: string
+        required: false
     secrets:
       ssh_private_key:
         description: "Optional SSH private key to be used when cloning additional plugin repos"
@@ -31,6 +34,7 @@ env:
 jobs:
   linting:
     runs-on: ${{ inputs.runs_on }}
+    container: ${{ inputs.container || 'discourse/discourse_test:slim' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -51,26 +55,12 @@ jobs:
             echo "manager=${{ env.JS_PKG_MANAGER_NULL_VALUE }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install package manager
-        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
-        run: npm install -g ${{ steps.js-pkg-manager.outputs.manager }}
-
-      - name: Set up Node.js
-        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: ${{ steps.js-pkg-manager.outputs.manager }}
-
       - name: Install JS dependencies
         if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         run: ${{ steps.js-pkg-manager.outputs.manager }} install --frozen-lockfile
 
-      - name: Set up ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.2"
-          bundler-cache: true
+      - name: Bundle install
+        run: bundle install
 
       - name: Check for .es6 files
         if: ${{ !cancelled() }}
@@ -168,7 +158,7 @@ jobs:
   tests:
     name: ${{ matrix.build_type || '' }}_tests
     runs-on: ${{ inputs.runs_on }}
-    container: discourse/discourse_test:slim${{ (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '' }}
+    container: ${{ inputs.container || format('discourse/discourse_test:slim{0}', (matrix.build_type == 'frontend' || matrix.build_type == 'system') && '-browsers' || '') }}
     timeout-minutes: 30
     needs: check_for_tests
 

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -9,6 +9,13 @@ on:
       core_ref:
         type: string
         required: false
+      runs_on:
+        type: string
+        required: false
+        default: "ubuntu-latest"
+      container:
+        type: string
+        required: false
     secrets:
       ssh_private_key:
         description: "Optional SSH private key to be used when cloning additional plugin repos"
@@ -23,7 +30,8 @@ env:
 
 jobs:
   linting:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
+    container: ${{ inputs.container || 'discourse/discourse_test:slim' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,26 +52,12 @@ jobs:
             echo "manager=${{ env.JS_PKG_MANAGER_NULL_VALUE }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install package manager
-        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
-        run: npm install -g ${{ steps.js-pkg-manager.outputs.manager }}
-
-      - name: Set up Node.js
-        if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: ${{ steps.js-pkg-manager.outputs.manager }}
-
       - name: Install JS dependencies
         if: steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE
         run: ${{ steps.js-pkg-manager.outputs.manager }} install --frozen-lockfile
 
-      - name: Set up ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.2"
-          bundler-cache: true
+      - name: Bundle install
+        run: bundle install
 
       - name: Check for .es6 files
         if: ${{ !cancelled() }}
@@ -126,7 +120,7 @@ jobs:
           fi
 
   check_for_tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runs_on }}
     outputs:
       matrix: ${{ steps.check_tests.outputs.matrix }}
       has_tests: ${{ steps.check_tests.outputs.has_tests }}
@@ -175,8 +169,8 @@ jobs:
     name: ${{ matrix.build_type || '' }}_tests
     needs: check_for_tests
     if: ${{ needs.check_for_tests.outputs.has_tests }}
-    runs-on: ubuntu-latest
-    container: discourse/discourse_test:slim-browsers
+    runs-on: ${{ inputs.runs_on }}
+    container: ${{ inputs.container || 'discourse/discourse_test:slim-browsers' }}
     timeout-minutes: 15
 
     strategy:

--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -14,10 +14,14 @@ jobs:
   theme-workflow:
     uses: ./.github/workflows/discourse-theme.yml
     with:
+      runs_on: "debian-12"
+      container: "discourse/discourse_test:release"
       repository: "discourse/DiscoTOC"
 
   plugin-workflow:
     uses: ./.github/workflows/discourse-plugin.yml
     with:
+      runs_on: "debian-12"
+      container: "discourse/discourse_test:release"
       repository: "discourse/discourse-assign"
       name: "discourse-assign"


### PR DESCRIPTION
The following changes have also been made in this commit to support this change:

1. Introduce the `container` input so that the container used to run the various jobs can be configured.
2. Switch the `linting` job to either use the `container` input or `discourse/discourse_test:slim` so we don't have to require the runner VMs to have `ruby` or `npm` installed.