### PR TITLE
DEV: Update workflow concurrency controls to use `github.ref_name`

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -25,7 +25,7 @@ on:
         required: false
 
 concurrency:
-  group: discourse-plugin-${{ format('{0}-{1}-{2}', github.head_ref || github.run_number, github.job, inputs.core_ref) }}
+  group: discourse-plugin-${{ format('{0}-{1}-{2}', github.ref_name, github.job, inputs.core_ref) }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -22,7 +22,7 @@ on:
         required: false
 
 concurrency:
-  group: discourse-theme-${{ format('{0}-{1}-{2}', github.head_ref || github.run_number, github.job, inputs.core_ref) }}
+  group: discourse-theme-${{ format('{0}-{1}-{2}', github.ref_name, github.job, inputs.core_ref) }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
`github.ref_name` is

> The short ref name of the branch or tag that triggered the workflow run. This value matches the branch or tag name shown on GitHub. For example, feature-branch-1.
>
> For pull requests, the format is <pr_number>/merge.

Not sure why we use `github.run_number` when it is a unique number for
each run of a workflow. `github.head_ref` is only present on pull request events so it is blank when the workflow is ran on
other branches.

By updating the key to `github.ref_name` + `github.job` we ensure that
only one workflow will be running for a given PR or branch.
