### PR TITLE
DEV: Update labels for our self hosted runners

### DIFF
--- a/.github/workflows/test-templates.yml
+++ b/.github/workflows/test-templates.yml
@@ -14,14 +14,14 @@ jobs:
   theme-workflow:
     uses: ./.github/workflows/discourse-theme.yml
     with:
-      runs_on: "debian-12"
+      runs_on: "debian-12-8core"
       container: "discourse/discourse_test:release"
       repository: "discourse/DiscoTOC"
 
   plugin-workflow:
     uses: ./.github/workflows/discourse-plugin.yml
     with:
-      runs_on: "debian-12"
+      runs_on: "debian-12-8core"
       container: "discourse/discourse_test:release"
       repository: "discourse/discourse-assign"
       name: "discourse-assign"


### PR DESCRIPTION
We have 8 and 16 cores runner now but 16 core runners are not quite
ready for prime time yet.
