### PR TITLE
FIX: Set default shell to bash

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -31,6 +31,10 @@ concurrency:
 env:
   JS_PKG_MANAGER_NULL_VALUE: "none"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   linting:
     runs-on: ${{ inputs.runs_on }}
@@ -89,7 +93,6 @@ jobs:
 
       - name: Prettier
         if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
-        shell: bash
         run: |
           ${{ steps.js-pkg-manager.outputs.manager }} prettier --version
           if [ -n "$(find assets -type f \( -name '*.scss' -or -name '*.js' -or -name '*.gjs' -or -name '*.hbs' \) 2>/dev/null)" ]; then
@@ -217,7 +220,6 @@ jobs:
         run: |
           echo "ruby_version=$RUBY_VERSION" >> $GITHUB_OUTPUT
           echo "debian_release=$DEBIAN_RELEASE" >> $GITHUB_OUTPUT
-        shell: bash
 
       - name: Bundler cache
         uses: actions/cache@v4

--- a/.github/workflows/discourse-theme.yml
+++ b/.github/workflows/discourse-theme.yml
@@ -28,6 +28,10 @@ concurrency:
 env:
   JS_PKG_MANAGER_NULL_VALUE: "none"
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   linting:
     runs-on: ${{ inputs.runs_on }}
@@ -86,7 +90,6 @@ jobs:
 
       - name: Prettier
         if: ${{ !cancelled() && steps.js-pkg-manager.outputs.manager != env.JS_PKG_MANAGER_NULL_VALUE }}
-        shell: bash
         run: |
           ${{ steps.js-pkg-manager.outputs.manager }} prettier --version
           files=$(find javascripts desktop mobile common scss -type f \( -name "*.scss" -or -name "*.js" -or -name "*.gjs" -or -name "*.hbs" \) 2> /dev/null) || true
@@ -226,7 +229,6 @@ jobs:
         run: |
           echo "ruby_version=$RUBY_VERSION" >> $GITHUB_OUTPUT
           echo "debian_release=$DEBIAN_RELEASE" >> $GITHUB_OUTPUT
-        shell: bash
 
       - name: Bundler cache
         uses: actions/cache@v4


### PR DESCRIPTION
In the discourse_test container, the default shell is `dash`, which does not support some of the glob expansion we're doing here. In particular, that means that the eslint step has been broken. Making bash the default will fix that issue, and should reduce the chance of it happening again.