### PR TITLE
FIX: Do not use pre-built assets for plugin qunit

### DIFF
--- a/.github/workflows/discourse-plugin.yml
+++ b/.github/workflows/discourse-plugin.yml
@@ -374,7 +374,7 @@ jobs:
         if: matrix.build_type == 'system' || matrix.build_type == 'frontend'
         env:
           EMBER_ENV: development
-          DISCOURSE_DOWNLOAD_PRE_BUILT_ASSETS: "1"
+          DISCOURSE_DOWNLOAD_PRE_BUILT_ASSETS: ${{ matrix.build_type == 'system' && '1' || '0' }}
         run: |
           if [ -f script/assemble_ember_build.rb ]; then
             script/assemble_ember_build.rb


### PR DESCRIPTION
This doesn't work because `tests/index.html` is not rebuilt with the correct plugins. Switching back to a full build for now.